### PR TITLE
Arrange visit dropdown in chronological order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # tidyCDISC (development version)
-
+* Arranged visits in dropdown menu under Stats column in chronological order.
 
 # tidyCDISC 0.2.0 (CRAN Release)
 

--- a/R/mod_tableGen.R
+++ b/R/mod_tableGen.R
@@ -261,7 +261,9 @@ mod_tableGen_server <- function(input, output, session, datafile = reactive(NULL
         dplyr::mutate(AVISIT = factor(AVISIT,
             levels = awd[order(awd$AVISITN), "AVISIT"][[1]] %>% unique() )) %>%
         dplyr::pull(AVISIT) %>%
-        unique()
+        unique() %>%
+        # Arrange by factor level (AVISITN)
+        sort()
     }
     avisit_words[avisit_words != ""]
   })


### PR DESCRIPTION
This addresses #154 .

This was happening when two or more non-ADSL datasets were loaded (e.g., ADSL, plus ADEG and ADVS). The visits needed to be sorted by AVISITN.

New output:

Example study 1:

![image](https://user-images.githubusercontent.com/16843423/217925888-60a585a2-2b4b-4532-8ee7-f39162c243d6.png)

Example study 2:

![image](https://user-images.githubusercontent.com/16843423/217925921-3f7b506f-d10f-4149-902b-febf31fbf91e.png)

