### PR TITLE
Format table output to look more CSR-like

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyCDISC
 Title: Quick Table Generation & Exploratory Analyses on ADaM-Ish Datasets
-Version: 0.2.0.9003
+Version: 0.2.0.9004
 Authors@R: c(
     person("Aaron", "Clark", , "clark.aaronchris@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0123-0970")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# tidyCDISC (development version)
+
 
 # tidyCDISC (development version)
 * Fixed bug accessing files in "app/www/" (#166)

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Fixed bug where wrong values were being passed as options for some lab tables (#169).
 * Fixed bug where draggable blocks were not working without inclusion of datasets with ATPT (#173)
 * Fixed bug where selected filters were not being applied in the Population Explorer when apply filters was toggled (#175)
+* Made the html output in the app look slightly more "CSR-like" using minor formatting
 
 
 # tidyCDISC 0.2.0 (CRAN Release)

--- a/R/mod_tableGen.R
+++ b/R/mod_tableGen.R
@@ -707,7 +707,10 @@ mod_tableGen_server <- function(input, output, session, datafile = reactive(NULL
       if(input$download_type == ".csv") {
         progress$inc(1) # increment progress bar
         
-        write.csv(for_gt(), file, row.names = FALSE)
+        write.csv(
+          for_gt() %>%
+            mutate(ID = ifelse(Variable == "", "", ID))
+            , file, row.names = FALSE)
         progress$inc(1) # increment progress bar
         
       } else if(input$download_type == ".html") {

--- a/R/mod_tableGen_utils.R
+++ b/R/mod_tableGen_utils.R
@@ -605,9 +605,7 @@ create_gt_table <- function(data, input_table_title, input_table_footnote,
                        stringr::str_detect(Variable,'<b>') |
                        stringr::str_detect(Variable,'</b>')) %>%
     gt::tab_options(table.width = gt::px(700),
-                    # row_group.border.bottom.style = "none",
-                    # table_body.hlines.style = "none"
-                    
+                    table.font.names = c("Times", "Arial"),
                     row_group.border.bottom.style = "none",
                     table_body.hlines.style = "none",
                     table.border.top.style = "none",

--- a/R/mod_tableGen_utils.R
+++ b/R/mod_tableGen_utils.R
@@ -606,6 +606,7 @@ create_gt_table <- function(data, input_table_title, input_table_footnote,
                        stringr::str_detect(Variable,'</b>')) %>%
     gt::tab_options(table.width = gt::px(700),
                     table.font.names = c("Times", "Arial"),
+                    # row_group.border.top.style = "none",
                     row_group.border.bottom.style = "none",
                     table_body.hlines.style = "none",
                     table.border.top.style = "none",

--- a/R/mod_tableGen_utils.R
+++ b/R/mod_tableGen_utils.R
@@ -485,9 +485,9 @@ std_footnote <- function(data, source) {
                 style="text-align:left"))
 }
 
-#' Create the gt table object for TG
+#' Prepare the table generator data for output
 #' 
-#' A wrapper for other functions to create the `gt` object from the data
+#' Prepare the data.frame so that it's ready for output via `gt` or other
 #' 
 #' @param tg_datalist A list containing the data frames used to create the table
 #' @param blockData The data for the construction of the blocks in the table
@@ -516,10 +516,24 @@ tg_gt <- function(tg_datalist, blockData, total_df, group) {
   if (rlang::is_empty(tbl_blocks))
     stop("There is no data for the selected pairs of analysis time points and visits.")
   
-  tbl_blocks %>%
+  data <- tbl_blocks %>%
     purrr::map(setNames, tidyCDISC::common_rownames(tg_datalist$POPDAT, group)) %>%
     dplyr::bind_rows(.id = 'ID') %>%
     dplyr::mutate(ID = tidyCDISC::pretty_IDs(ID))
+  
+  # Add blank row after each ID group
+  # Change factor to character to maintain order of blocks
+  data_factor <- data %>%
+    mutate(ID = factor(ID, levels = unique(ID)))
+  
+  # Add blank rows
+  data_with_blank_rows <- do.call(rbind, by(data, data_factor$ID, rbind, ""))
+  
+  # Populate ID in blank rows
+  ind <- which(data_with_blank_rows$ID == "")
+  data_with_blank_rows$ID[ind] <- data_with_blank_rows$ID[ind - 1]
+  
+  return(data_with_blank_rows)
 }
 
 #' Table Generator Cicerone R6 Object 
@@ -599,22 +613,9 @@ tg_guide <- cicerone::Cicerone$
 create_gt_table <- function(data, input_table_title, input_table_footnote,
                             col_names, col_total, subtitle) {
   
-  # Add blank row after each ID group
-
-  # Change factor to character to maintain order of blocks
-  data_factor <- data %>%
-    mutate(ID = factor(ID, levels = unique(ID)))
-
-  # Add blank rows
-  data_with_blank_rows <- do.call(rbind, by(data, data_factor$ID, rbind, ""))
-
-  # Populate ID in blank rows
-  ind <- which(data_with_blank_rows$ID == "")
-  data_with_blank_rows$ID[ind] <- data_with_blank_rows$ID[ind - 1]
-
   
   
-  data_with_blank_rows %>%
+  data %>%
     gt::gt(groupname_col = "ID") %>%
     gt::fmt_markdown(columns = c(Variable),
                      rows = stringr::str_detect(Variable,'&nbsp;') |

--- a/R/mod_tableGen_utils.R
+++ b/R/mod_tableGen_utils.R
@@ -604,7 +604,15 @@ create_gt_table <- function(data, input_table_title, input_table_footnote,
                      rows = stringr::str_detect(Variable,'&nbsp;') |
                        stringr::str_detect(Variable,'<b>') |
                        stringr::str_detect(Variable,'</b>')) %>%
-    gt::tab_options(table.width = gt::px(700)) %>%
+    gt::tab_options(table.width = gt::px(700),
+                    # row_group.border.bottom.style = "none",
+                    # table_body.hlines.style = "none"
+                    
+                    row_group.border.bottom.style = "none",
+                    table_body.hlines.style = "none",
+                    table.border.top.style = "none",
+                    table.border.bottom.style = "none"
+                    ) %>%
     gt::cols_label(.list = col_for_list_expr(col_names, col_total)) %>%
     gt::tab_header(
       title = gt::md(input_table_title),

--- a/data-raw/examples_data.R
+++ b/data-raw/examples_data.R
@@ -1,3 +1,5 @@
+library(dplyr)
+library(gt)
 datalist <- list(ADSL = tidyCDISC::adsl, ADVS = tidyCDISC::advs, ADAE = tidyCDISC::adae, ADLBC = tidyCDISC::adlbc)
 pre_adsl <- tidyCDISC::prep_adsl(datalist$ADSL[1:25,], input_recipe = 'NONE')
 # Create AE data set
@@ -62,7 +64,7 @@ tg_table <- purrr::pmap(list(
                                            group = 'TRT01P',
                                            data = tidyCDISC::data_to_use_str(d, ae_data, bds_data),
                                            totals = total_df)) %>%
-  map(setNames, tidyCDISC::common_rownames(pop_data, 'TRT01P')) %>%
+  purrr::map(setNames, tidyCDISC::common_rownames(pop_data, 'TRT01P')) %>%
   setNames(paste(blockData$gt_group)) %>%
   bind_rows(.id = 'ID') %>%
   mutate(ID = tidyCDISC::pretty_IDs(ID))

--- a/man/tg_gt.Rd
+++ b/man/tg_gt.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/mod_tableGen_utils.R
 \name{tg_gt}
 \alias{tg_gt}
-\title{Create the gt table object for TG}
+\title{Prepare the table generator data for output}
 \usage{
 tg_gt(tg_datalist, blockData, total_df, group)
 }
@@ -19,6 +19,6 @@ tg_gt(tg_datalist, blockData, total_df, group)
 a data.frame containing output polished for presentation in `gt`
 }
 \description{
-A wrapper for other functions to create the `gt` object from the data
+Prepare the data.frame so that it's ready for output via `gt` or other
 }
 \keyword{tabGen_repro}


### PR DESCRIPTION
Closes #180.

The existing output just looks really "busy" and I think this could be one small step in the direction of making the output look more "rtf-like". I have two options to present below.

Previously:
![image](https://user-images.githubusercontent.com/17878953/222473553-6a7d985a-2d3a-4063-8e4b-fb5504100e79.png)


Polished RTF: Please ignore the `B`'s and extra treatment total column
![image](https://user-images.githubusercontent.com/17878953/222473012-0df512a9-2935-4d11-829b-ce07ab145449.png)


Option 1: removes line under each row group and between all values, but keeps top & bottom lines.
![image](https://user-images.githubusercontent.com/17878953/222471666-0c51f47d-3dbf-43cc-a1ee-fe1658521101.png)

Option 2: same as option1, but also removes lines on top and bottom lines.
![image](https://user-images.githubusercontent.com/17878953/222471832-239e71f7-f669-4986-8904-1327eea67035.png)
