### PR TITLE
Add blank rows to HTML output

### DIFF
--- a/R/mod_tableGen.R
+++ b/R/mod_tableGen.R
@@ -965,7 +965,13 @@ mod_tableGen_server <- function(input, output, session, datafile = reactive(NULL
                  rows = stringr::str_detect(Variable,'&nbsp;') |
                    stringr::str_detect(Variable,'<b>') |
                    stringr::str_detect(Variable,'</b>')) %>%
-          tab_options(table.width = px(700)) %>%
+          tab_options(table.width = px(700),
+                    table.font.names = c('Times', 'Arial'),
+                    row_group.border.top.style = 'none',
+                    row_group.border.bottom.style = 'none',
+                    table_body.hlines.style = 'none',
+                    table.border.top.style = 'none',
+                    table.border.bottom.style = 'none') %>%
           cols_label(.list = tidyCDISC::col_for_list_expr(col_names, col_total)) %>%
           tab_header(
             title = md('{input$table_title}'),

--- a/R/mod_tableGen.R
+++ b/R/mod_tableGen.R
@@ -580,22 +580,8 @@ mod_tableGen_server <- function(input, output, session, datafile = reactive(NULL
     
     data <- for_gt()
     
-    # Add blank row after each ID group
-    
-    # Change factor to character to maintain order of blocks
-    data_factor <- data %>%
-      mutate(ID = factor(ID, levels = unique(ID)))
-    
-    # Add blank rows
-    data_with_blank_rows <- do.call(rbind, by(data, data_factor$ID, rbind, ""))
-    
-    # Populate ID in blank rows
-    ind <- which(data_with_blank_rows$ID == "")
-    data_with_blank_rows$ID[ind] <- data_with_blank_rows$ID[ind - 1]
-    
-    
     # Convert to gt table object
-    gt_tab <- create_gt_table(data_with_blank_rows, 
+    gt_tab <- create_gt_table(data, 
                               input_table_title = input$table_title, 
                               input_table_footnote = input$table_footnote, 
                               col_names = row_names_n(), 

--- a/R/mod_tableGen_utils.R
+++ b/R/mod_tableGen_utils.R
@@ -598,7 +598,23 @@ tg_guide <- cicerone::Cicerone$
 #' @noRd
 create_gt_table <- function(data, input_table_title, input_table_footnote,
                             col_names, col_total, subtitle) {
-  data %>%
+  
+  # Add blank row after each ID group
+
+  # Change factor to character to maintain order of blocks
+  data_factor <- data %>%
+    mutate(ID = factor(ID, levels = unique(ID)))
+
+  # Add blank rows
+  data_with_blank_rows <- do.call(rbind, by(data, data_factor$ID, rbind, ""))
+
+  # Populate ID in blank rows
+  ind <- which(data_with_blank_rows$ID == "")
+  data_with_blank_rows$ID[ind] <- data_with_blank_rows$ID[ind - 1]
+
+  
+  
+  data_with_blank_rows %>%
     gt::gt(groupname_col = "ID") %>%
     gt::fmt_markdown(columns = c(Variable),
                      rows = stringr::str_detect(Variable,'&nbsp;') |
@@ -606,7 +622,7 @@ create_gt_table <- function(data, input_table_title, input_table_footnote,
                        stringr::str_detect(Variable,'</b>')) %>%
     gt::tab_options(table.width = gt::px(700),
                     table.font.names = c("Times", "Arial"),
-                    # row_group.border.top.style = "none",
+                    row_group.border.top.style = "none",
                     row_group.border.bottom.style = "none",
                     table_body.hlines.style = "none",
                     table.border.top.style = "none",

--- a/data-raw/examples_data.R
+++ b/data-raw/examples_data.R
@@ -77,7 +77,13 @@ tg_table2 <-
                rows = stringr::str_detect(Variable,'&nbsp;') |
                  stringr::str_detect(Variable,'<b>') |
                  stringr::str_detect(Variable,'</b>')) %>%
-  tab_options(table.width = gt::px(700)) %>%
+  tab_options(table.width = gt::px(700),
+              table.font.names = c('Times', 'Arial'),
+              row_group.border.top.style = 'none',
+              row_group.border.bottom.style = 'none',
+              table_body.hlines.style = 'none',
+              table.border.top.style = 'none',
+              table.border.bottom.style = 'none') %>%
   tab_header(
     title = md('Table Title'),
     subtitle = md(" ")


### PR DESCRIPTION
I added blank lines between groups and set `row_group.border.top.style = "none"`. This is the new HTML output:

![image](https://user-images.githubusercontent.com/16843423/222519508-37fbed5e-ee54-4700-8ecd-1f5991e0f532.png)

