### PR TITLE
Fix heatmap not displaying Time Dependent axis values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # tidyCDISC (development version)
+- Allowed for one-element lists in heatmap axis dropdowns.
 
 # tidyCDISC 0.2.1 (CRAN Release)
 

--- a/R/mod_popExp_heatCorr.R
+++ b/R/mod_popExp_heatCorr.R
@@ -110,6 +110,13 @@ heatmap_srv <- function(input, output, session, data, run) {
     }) %>%
       na.omit() %>% as.character()
     
+    # If there is only one paramcd, need to pass to choices() as a one-element
+    # named list so that the name appears in dropdown
+    if (length(paramcd) == 1) {
+      paramcd <- c(paramcd)
+      names(paramcd) <- paramcd
+    }
+    
     updateSelectInput(session, "yvar_x",
                       choices = list(`Time Dependent` = paramcd,`Time Independent` = num_col),
                       selected = isolate(input$yvar_x))

--- a/R/mod_popExp_heatCorr.R
+++ b/R/mod_popExp_heatCorr.R
@@ -108,14 +108,10 @@ heatmap_srv <- function(input, output, session, data, run) {
         nrow()
       ifelse(rows > 0, NA_character_, test_pcd)
     }) %>%
-      na.omit() %>% as.character()
-    
-    # If there is only one paramcd, need to pass to choices() as a one-element
-    # named list so that the name appears in dropdown
-    if (length(paramcd) == 1) {
-      paramcd <- c(paramcd)
-      names(paramcd) <- paramcd
-    }
+      na.omit() %>% as.character() %>%
+      # Convert to list so that one-element vectors are displayed correctly
+      # in the dropdown
+      as.list()
     
     updateSelectInput(session, "yvar_x",
                       choices = list(`Time Dependent` = paramcd,`Time Independent` = num_col),


### PR DESCRIPTION
Addresses #214 .

For the study selected, there was only one Time Dependent value ("HEIGHT"). Since there was only one value, the dropdown menu was displaying "Time Dependent" as the label. The name had to be explicitly assigned in order for it to display.