### PR TITLE
Group by `AVISIT` for scatterplots and display back up labels when needed

### DIFF
--- a/R/mod_popExp_fct_boxplot.R
+++ b/R/mod_popExp_fct_boxplot.R
@@ -25,10 +25,10 @@ app_boxplot <- function(data, yvar, group, value = NULL, points = FALSE) {
     # initialize plot
     p <- ggplot2::ggplot(data) + 
       ggplot2::aes_string(x = group, y = yvar) +
-      ggplot2::ylab(attr(data[[yvar]], "label") %||% yvar)
+      ggplot2::ylab(label_me(data, yvar))
     
     # initialize title with variable of interst
-    var_title <- paste(attr(data[[yvar]], 'label') %||% yvar, "by", attr(data[[group]], "label") %||% group)
+    var_title <- paste(label_me(data, yvar), "by", label_me(data, group))
     
   # BDS Param selected
   } else {
@@ -37,13 +37,13 @@ app_boxplot <- function(data, yvar, group, value = NULL, points = FALSE) {
     
     # Initialize title with variable selected
     var_label <- paste(unique(d$PARAM))
-    var_title <- paste(var_label, "by", attr(data[[group]], "label") %||% group)
+    var_title <- paste(var_label, "by", label_me(data, group))
     
     # Initialize plot
     p <- d %>%
       ggplot2::ggplot() +
       ggplot2::aes_string(x = group, y = value) +
-      ggplot2::ylab(glue::glue("{var_label} ({attr(data[[value]], 'label') %||% group})"))
+      ggplot2::ylab(glue::glue("{var_label} ({label_me(data, value)})"))
   }
   
   # Add layer of common plot elements

--- a/R/mod_popExp_fct_boxplot.R
+++ b/R/mod_popExp_fct_boxplot.R
@@ -25,10 +25,10 @@ app_boxplot <- function(data, yvar, group, value = NULL, points = FALSE) {
     # initialize plot
     p <- ggplot2::ggplot(data) + 
       ggplot2::aes_string(x = group, y = yvar) +
-      ggplot2::ylab(attr(data[[yvar]], "label"))
+      ggplot2::ylab(attr(data[[yvar]], "label") %||% yvar)
     
     # initialize title with variable of interst
-    var_title <- paste(attr(data[[yvar]], 'label'), "by", attr(data[[group]], "label"))
+    var_title <- paste(attr(data[[yvar]], 'label') %||% yvar, "by", attr(data[[group]], "label") %||% group)
     
   # BDS Param selected
   } else {
@@ -37,13 +37,13 @@ app_boxplot <- function(data, yvar, group, value = NULL, points = FALSE) {
     
     # Initialize title with variable selected
     var_label <- paste(unique(d$PARAM))
-    var_title <- paste(var_label, "by", attr(data[[group]], "label"))
+    var_title <- paste(var_label, "by", attr(data[[group]], "label") %||% group)
     
     # Initialize plot
     p <- d %>%
       ggplot2::ggplot() +
       ggplot2::aes_string(x = group, y = value) +
-      ggplot2::ylab(glue::glue("{var_label} ({attr(data[[value]], 'label')})"))
+      ggplot2::ylab(glue::glue("{var_label} ({attr(data[[value]], 'label') %||% group})"))
   }
   
   # Add layer of common plot elements

--- a/R/mod_popExp_fct_boxplot.R
+++ b/R/mod_popExp_fct_boxplot.R
@@ -25,10 +25,10 @@ app_boxplot <- function(data, yvar, group, value = NULL, points = FALSE) {
     # initialize plot
     p <- ggplot2::ggplot(data) + 
       ggplot2::aes_string(x = group, y = yvar) +
-      ggplot2::ylab(label_me(data, yvar))
+      ggplot2::ylab(best_lab(data, yvar))
     
     # initialize title with variable of interst
-    var_title <- paste(label_me(data, yvar), "by", label_me(data, group))
+    var_title <- paste(best_lab(data, yvar), "by", best_lab(data, group))
     
   # BDS Param selected
   } else {
@@ -37,13 +37,13 @@ app_boxplot <- function(data, yvar, group, value = NULL, points = FALSE) {
     
     # Initialize title with variable selected
     var_label <- paste(unique(d$PARAM))
-    var_title <- paste(var_label, "by", label_me(data, group))
+    var_title <- paste(var_label, "by", best_lab(data, group))
     
     # Initialize plot
     p <- d %>%
       ggplot2::ggplot() +
       ggplot2::aes_string(x = group, y = value) +
-      ggplot2::ylab(glue::glue("{var_label} ({label_me(data, value)})"))
+      ggplot2::ylab(glue::glue("{var_label} ({best_lab(data, value)})"))
   }
   
   # Add layer of common plot elements

--- a/R/mod_popExp_fct_km.R
+++ b/R/mod_popExp_fct_km.R
@@ -54,7 +54,7 @@ app_km_curve <- function(data, yvar, resp_var, cnsr_var, group = "NONE", points 
   # Initialize title of variables plotted
   # if group used, include those "by" variables in title
   by_title <- case_when(
-    group != "NONE" ~ paste("\nby", attr(data[[group]], "label") %||% group), 
+    group != "NONE" ~ paste("\nby", label_me(data, group)),
     TRUE ~ ""
   )
   

--- a/R/mod_popExp_fct_km.R
+++ b/R/mod_popExp_fct_km.R
@@ -54,7 +54,7 @@ app_km_curve <- function(data, yvar, resp_var, cnsr_var, group = "NONE", points 
   # Initialize title of variables plotted
   # if group used, include those "by" variables in title
   by_title <- case_when(
-    group != "NONE" ~ paste("\nby", label_me(data, group)),
+    group != "NONE" ~ paste("\nby", best_lab(data, group)),
     TRUE ~ ""
   )
   

--- a/R/mod_popExp_fct_km.R
+++ b/R/mod_popExp_fct_km.R
@@ -54,7 +54,7 @@ app_km_curve <- function(data, yvar, resp_var, cnsr_var, group = "NONE", points 
   # Initialize title of variables plotted
   # if group used, include those "by" variables in title
   by_title <- case_when(
-    group != "NONE" ~ paste("\nby", attr(data[[group]], "label")), 
+    group != "NONE" ~ paste("\nby", attr(data[[group]], "label") %||% group), 
     TRUE ~ ""
   )
   

--- a/R/mod_popExp_fct_line.R
+++ b/R/mod_popExp_fct_line.R
@@ -65,7 +65,7 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
     yvar_label <- ifelse(rlang::is_empty(paste(unique(d0$PARAM))), yvar, paste(unique(d0$PARAM)))
     yl <- glue::glue("{yvar_label} ({label_me(data, value)})")
   }
-  xl <- label_me(d0, time) # ifelse(rlang::is_empty(attr(d0[[time]], "label")), time, attr(d0[[time]], "label"))
+  xl <- label_me(d0, time) 
   y_lab <- paste(ifelse(value == "CHG", "Mean Change from Baseline", "Mean"), yvar_label)
   
   val_sym <- rlang::sym("val")

--- a/R/mod_popExp_fct_line.R
+++ b/R/mod_popExp_fct_line.R
@@ -68,7 +68,7 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
         select(USUBJID, time, one_of(timeN), PARAM, PARAMCD, val = value, one_of(color, colorN, separate, separateN))
     )
     yvar_label <- ifelse(rlang::is_empty(paste(unique(d0$PARAM))), yvar, paste(unique(d0$PARAM)))
-    yl <- glue::glue("{yvar_label} ({attr(data[[value]], 'label')})")
+    yl <- glue::glue("{yvar_label} ({attr(data[[value]], 'label') %||% value})")
   }
   xl <- ifelse(rlang::is_empty(attr(d0[[time]], "label")), time, attr(d0[[time]], "label"))
   y_lab <- paste(ifelse(value == "CHG", "Mean Change from Baseline", "Mean"), yvar_label)
@@ -118,12 +118,13 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
   # if separate or color used, include those "by" variables in title
   var_title <- paste(y_lab, "by", xl)
   by_title <- case_when(
-    separate == color & color != "NONE" ~ paste("\nby", attr(data[[color]], "label")),
-    separate != "NONE" & color != "NONE" ~ paste("\nby", attr(data[[color]], "label"), "and", attr(data[[separate]], "label")),
-    separate != "NONE" ~ paste("\nby", attr(data[[separate]], "label")),
-    color != "NONE" ~ paste("\nby", attr(data[[color]], "label")), 
+    separate == color & color != "NONE" ~  paste("\nby", attr(data[[color]], "label") %||% color),
+    separate != "NONE" & color != "NONE" ~ paste("\nby", attr(data[[color]], "label") %||% color, "and", attr(data[[separate]], "label") %||% separate),
+    separate != "NONE" ~ paste("\nby", attr(data[[separate]], "label") %||% separate),
+    color != "NONE" ~ paste("\nby", attr(data[[color]], "label") %||% color), 
     TRUE ~ ""
   )
+  
   
   dodge <- ggplot2::position_dodge(.9)
   time_sym <- rlang::sym(time)

--- a/R/mod_popExp_fct_line.R
+++ b/R/mod_popExp_fct_line.R
@@ -54,18 +54,18 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
     suppressWarnings(
       d0 <- data0 %>% select(USUBJID, time, one_of(timeN), val = yvar, one_of(color, colorN, separate, separateN))
     )
-    yvar_label <- yl <- label_me(data, yvar)
+    yvar_label <- yl <- best_lab(data, yvar)
   } else {
     suppressWarnings(
       d0 <- data0 %>%
         dplyr::filter(PARAMCD == yvar) %>%
         select(USUBJID, time, one_of(timeN), PARAM, PARAMCD, val = value, one_of(color, colorN, separate, separateN))
     )
-    # do not use label_me() since this is checking for an empty string
+    # do not use best_lab() since this is checking for an empty string
     yvar_label <- ifelse(rlang::is_empty(paste(unique(d0$PARAM))), yvar, paste(unique(d0$PARAM)))
-    yl <- glue::glue("{yvar_label} ({label_me(data, value)})")
+    yl <- glue::glue("{yvar_label} ({best_lab(data, value)})")
   }
-  xl <- label_me(d0, time) 
+  xl <- best_lab(d0, time) 
   y_lab <- paste(ifelse(value == "CHG", "Mean Change from Baseline", "Mean"), yvar_label)
   
   val_sym <- rlang::sym("val")
@@ -113,10 +113,10 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
   # if separate or color used, include those "by" variables in title
   var_title <- paste(y_lab, "by", xl)
   by_title <- case_when(
-    separate == color & color != "NONE" ~  paste("\nby", label_me(data, color)), 
-    separate != "NONE" & color != "NONE" ~ paste("\nby", label_me(data, color), "and", label_me(data, separate)), 
-    separate != "NONE" ~ paste("\nby", label_me(data, separate)),
-    color != "NONE" ~ paste("\nby", label_me(data, color)), 
+    separate == color & color != "NONE" ~  paste("\nby", best_lab(data, color)), 
+    separate != "NONE" & color != "NONE" ~ paste("\nby", best_lab(data, color), "and", best_lab(data, separate)), 
+    separate != "NONE" ~ paste("\nby", best_lab(data, separate)),
+    color != "NONE" ~ paste("\nby", best_lab(data, color)), 
     TRUE ~ ""
   )
   

--- a/R/mod_popExp_fct_line.R
+++ b/R/mod_popExp_fct_line.R
@@ -49,28 +49,23 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
   colorN <- paste0(color, "N")
   separateN <- paste0(separate, "N")
     
-  # print(unique(data0[,c("AVISIT", "AVISITN")]))
-  # print(".")
-  # print(levels(data0$AVISIT))
-  # print(".")
-  # print(unique(data0$AVISIT))
-  # print(".")
   # subset data based on yvar being paramcd or not
   if (yvar %in% colnames(data)) {
     suppressWarnings(
       d0 <- data0 %>% select(USUBJID, time, one_of(timeN), val = yvar, one_of(color, colorN, separate, separateN))
     )
-    yvar_label <- yl <- ifelse(rlang::is_empty(attr(data[[yvar]], "label")), yvar, attr(data[[yvar]], "label"))
+    yvar_label <- yl <- label_me(data, yvar)
   } else {
     suppressWarnings(
       d0 <- data0 %>%
         dplyr::filter(PARAMCD == yvar) %>%
         select(USUBJID, time, one_of(timeN), PARAM, PARAMCD, val = value, one_of(color, colorN, separate, separateN))
     )
+    # do not use label_me() since this is checking for an empty string
     yvar_label <- ifelse(rlang::is_empty(paste(unique(d0$PARAM))), yvar, paste(unique(d0$PARAM)))
-    yl <- glue::glue("{yvar_label} ({attr(data[[value]], 'label') %||% value})")
+    yl <- glue::glue("{yvar_label} ({label_me(data, value)})")
   }
-  xl <- ifelse(rlang::is_empty(attr(d0[[time]], "label")), time, attr(d0[[time]], "label"))
+  xl <- label_me(d0, time) # ifelse(rlang::is_empty(attr(d0[[time]], "label")), time, attr(d0[[time]], "label"))
   y_lab <- paste(ifelse(value == "CHG", "Mean Change from Baseline", "Mean"), yvar_label)
   
   val_sym <- rlang::sym("val")
@@ -118,10 +113,10 @@ app_lineplot <- function(data, yvar, time, value = NULL, separate = "NONE", colo
   # if separate or color used, include those "by" variables in title
   var_title <- paste(y_lab, "by", xl)
   by_title <- case_when(
-    separate == color & color != "NONE" ~  paste("\nby", attr(data[[color]], "label") %||% color),
-    separate != "NONE" & color != "NONE" ~ paste("\nby", attr(data[[color]], "label") %||% color, "and", attr(data[[separate]], "label") %||% separate),
-    separate != "NONE" ~ paste("\nby", attr(data[[separate]], "label") %||% separate),
-    color != "NONE" ~ paste("\nby", attr(data[[color]], "label") %||% color), 
+    separate == color & color != "NONE" ~  paste("\nby", label_me(data, color)), 
+    separate != "NONE" & color != "NONE" ~ paste("\nby", label_me(data, color), "and", label_me(data, separate)), 
+    separate != "NONE" ~ paste("\nby", label_me(data, separate)),
+    color != "NONE" ~ paste("\nby", label_me(data, color)), 
     TRUE ~ ""
   )
   

--- a/R/mod_popExp_fct_scatterplot.R
+++ b/R/mod_popExp_fct_scatterplot.R
@@ -51,9 +51,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # Initialize plot x & y vars
     x.var <- xvar
-    x.lab <- label_me(data, xvar)
+    x.lab <- best_lab(data, xvar)
     y.var <- yvar
-    y.lab <- label_me(data, yvar)
+    y.lab <- best_lab(data, yvar)
     
     # Initialize title of variables plotted
     var_title <- paste(y.lab, "versus", x.lab)
@@ -78,9 +78,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # initialize plot x & y vars
     x.var <- value_x
-    x.lab <- glue::glue("{unique(d$PARAM)}: {week_x} ({label_me(data, value_x)})") 
+    x.lab <- glue::glue("{unique(d$PARAM)}: {week_x} ({best_lab(data, value_x)})") 
     y.var <- yvar
-    y.lab <- label_me(data, yvar)
+    y.lab <- best_lab(data, yvar)
     
     # Initialize title of variables plotted
     var_title <- paste(y.lab, "versus", unique(d$PARAM), "at", week_x)
@@ -105,9 +105,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # initialize plot x & y vars
     x.var <- xvar
-    x.lab <- label_me(data, xvar) 
+    x.lab <- best_lab(data, xvar) 
     y.var <- value_y
-    y.lab <- glue::glue("{unique(d$PARAM)}: {week_y} ({label_me(data, value_y)})") 
+    y.lab <- glue::glue("{unique(d$PARAM)}: {week_y} ({best_lab(data, value_y)})") 
     
     # Initialize title of variables plotted
     var_title <- paste(unique(d$PARAM), "at", week_y, "versus", x.lab)
@@ -218,9 +218,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # Initialize plot x & y vars
     x.var <- xvar
-    x.lab <- glue::glue("{unique(x_data$PARAM)}: {week_x} ({label_me(data, value_x)})")
+    x.lab <- glue::glue("{unique(x_data$PARAM)}: {week_x} ({best_lab(data, value_x)})")
     y.var <- yvar
-    y.lab <- glue::glue("{unique(y_data$PARAM)}: {week_y} ({label_me(data, value_y)})")
+    y.lab <- glue::glue("{unique(y_data$PARAM)}: {week_y} ({best_lab(data, value_y)})")
     
     # Initialize title of variables plotted
     var_title <- paste(unique(y_data$PARAM),"versus", unique(x_data$PARAM))
@@ -234,10 +234,10 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
 
   # if separate or color used, include those "by" variables in title
   by_title <- case_when(
-    separate == color & color != "NONE" ~  paste("\nby", label_me(data, color)), 
-    separate != "NONE" & color != "NONE" ~ paste("\nby", label_me(data, color), "and", label_me(data, separate)), 
-    separate != "NONE" ~ paste("\nby", label_me(data, separate)),
-    color != "NONE" ~ paste("\nby", label_me(data, color)), 
+    separate == color & color != "NONE" ~  paste("\nby", best_lab(data, color)), 
+    separate != "NONE" & color != "NONE" ~ paste("\nby", best_lab(data, color), "and", best_lab(data, separate)), 
+    separate != "NONE" ~ paste("\nby", best_lab(data, separate)),
+    color != "NONE" ~ paste("\nby", best_lab(data, color)), 
     TRUE ~ ""
   )
 

--- a/R/mod_popExp_fct_scatterplot.R
+++ b/R/mod_popExp_fct_scatterplot.R
@@ -51,9 +51,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # Initialize plot x & y vars
     x.var <- xvar
-    x.lab <- attr(data[[xvar]], 'label') %||% xvar
+    x.lab <- label_me(data, xvar)
     y.var <- yvar
-    y.lab <- attr(data[[yvar]], 'label') %||% yvar
+    y.lab <- label_me(data, yvar)
     
     # Initialize title of variables plotted
     var_title <- paste(y.lab, "versus", x.lab)
@@ -78,9 +78,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # initialize plot x & y vars
     x.var <- value_x
-    x.lab <- glue::glue("{unique(d$PARAM)}: {week_x} ({attr(data[[value_x]], 'label') %||% value_x})")
+    x.lab <- glue::glue("{unique(d$PARAM)}: {week_x} ({label_me(data, value_x)})") 
     y.var <- yvar
-    y.lab <- attr(data[[yvar]], 'label') %||% yvar
+    y.lab <- label_me(data, yvar)
     
     # Initialize title of variables plotted
     var_title <- paste(y.lab, "versus", unique(d$PARAM), "at", week_x)
@@ -105,9 +105,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # initialize plot x & y vars
     x.var <- xvar
-    x.lab <- attr(data[[xvar]], 'label') %||% xvar
+    x.lab <- label_me(data, xvar) 
     y.var <- value_y
-    y.lab <- glue::glue("{unique(d$PARAM)}: {week_y} ({attr(data[[value_y]], 'label') %||% value_y})")
+    y.lab <- glue::glue("{unique(d$PARAM)}: {week_y} ({label_me(data, value_y)})") 
     
     # Initialize title of variables plotted
     var_title <- paste(unique(d$PARAM), "at", week_y, "versus", x.lab)
@@ -218,9 +218,9 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
     
     # Initialize plot x & y vars
     x.var <- xvar
-    x.lab <- glue::glue("{unique(x_data$PARAM)}: {week_x} ({attr(data[[value_x]], 'label') %||% value_x})")
+    x.lab <- glue::glue("{unique(x_data$PARAM)}: {week_x} ({label_me(data, value_x)})")
     y.var <- yvar
-    y.lab <- glue::glue("{unique(y_data$PARAM)}: {week_y} ({attr(data[[value_y]], 'label') %||% value_y})")
+    y.lab <- glue::glue("{unique(y_data$PARAM)}: {week_y} ({label_me(data, value_y)})")
     
     # Initialize title of variables plotted
     var_title <- paste(unique(y_data$PARAM),"versus", unique(x_data$PARAM))
@@ -234,10 +234,10 @@ app_scatterplot <- function(data, yvar, xvar, week_x, value_x, week_y, value_y, 
 
   # if separate or color used, include those "by" variables in title
   by_title <- case_when(
-    separate == color & color != "NONE" ~  paste("\nby", attr(data[[color]], "label") %||% color),
-    separate != "NONE" & color != "NONE" ~ paste("\nby", attr(data[[color]], "label") %||% color, "and", attr(data[[separate]], "label") %||% separate),
-    separate != "NONE" ~ paste("\nby", attr(data[[separate]], "label") %||% separate),
-    color != "NONE" ~ paste("\nby", attr(data[[color]], "label") %||% color), 
+    separate == color & color != "NONE" ~  paste("\nby", label_me(data, color)), 
+    separate != "NONE" & color != "NONE" ~ paste("\nby", label_me(data, color), "and", label_me(data, separate)), 
+    separate != "NONE" ~ paste("\nby", label_me(data, separate)),
+    color != "NONE" ~ paste("\nby", label_me(data, color)), 
     TRUE ~ ""
   )
 

--- a/R/mod_popExp_fct_spaghettiplot.R
+++ b/R/mod_popExp_fct_spaghettiplot.R
@@ -23,11 +23,11 @@ app_spaghettiplot <- function(data, yvar, time, value = NULL) {
     # initialize plot
     p <- ggplot2::ggplot(data) + 
       ggplot2::aes_string(x = time, y = yvar, group = "USUBJID") +
-      ggplot2::ylab(attr(data[[yvar]], "label")) +
-      ggplot2::xlab(attr(data[[time]], "label"))
+      ggplot2::ylab(attr(data[[yvar]], "label") %||% yvar) +
+      ggplot2::xlab(attr(data[[time]], "label") %||% time)
     
     # initialize title with variables plotted
-    var_title <- paste(attr(data[[yvar]], 'label'), "by", attr(data[[time]], "label"))
+    var_title <- paste(attr(data[[yvar]], 'label') %||% yvar, "by", attr(data[[time]], "label") %||% time)
     
   } else {
     
@@ -36,16 +36,16 @@ app_spaghettiplot <- function(data, yvar, time, value = NULL) {
     
     # initialize title with variables plotted
     var_label <- paste(unique(d$PARAM))
-    var_title <- paste(var_label, "by", attr(data[[time]], "label"))
+    var_title <- paste(var_label, "by", attr(data[[time]], "label") %||% time)
     
     # initialize plot
     p <- d %>%
       ggplot2::ggplot() +
       ggplot2::aes_string(x = time, y = value, group = "USUBJID")  +
       ggplot2::ylab(
-        glue::glue("{var_label} ({attr(d[[value]], 'label')})")
+        glue::glue("{var_label} ({attr(d[[value]], 'label') %||% value})")
       ) +
-      ggplot2::xlab(attr(data[[time]], "label"))
+      ggplot2::xlab(attr(data[[time]], "label") %||% time)
   }
   
   # Add common layers to plot

--- a/R/mod_popExp_fct_spaghettiplot.R
+++ b/R/mod_popExp_fct_spaghettiplot.R
@@ -23,11 +23,11 @@ app_spaghettiplot <- function(data, yvar, time, value = NULL) {
     # initialize plot
     p <- ggplot2::ggplot(data) + 
       ggplot2::aes_string(x = time, y = yvar, group = "USUBJID") +
-      ggplot2::ylab(attr(data[[yvar]], "label") %||% yvar) +
-      ggplot2::xlab(attr(data[[time]], "label") %||% time)
+      ggplot2::ylab(label_me(data, yvar)) +
+      ggplot2::xlab(label_me(data, time))
     
     # initialize title with variables plotted
-    var_title <- paste(attr(data[[yvar]], 'label') %||% yvar, "by", attr(data[[time]], "label") %||% time)
+    var_title <- paste(label_me(data, yvar), "by", label_me(data, time))
     
   } else {
     
@@ -36,16 +36,16 @@ app_spaghettiplot <- function(data, yvar, time, value = NULL) {
     
     # initialize title with variables plotted
     var_label <- paste(unique(d$PARAM))
-    var_title <- paste(var_label, "by", attr(data[[time]], "label") %||% time)
+    var_title <- paste(var_label, "by", label_me(data, time))
     
     # initialize plot
     p <- d %>%
       ggplot2::ggplot() +
       ggplot2::aes_string(x = time, y = value, group = "USUBJID")  +
       ggplot2::ylab(
-        glue::glue("{var_label} ({attr(d[[value]], 'label') %||% value})")
+        glue::glue("{var_label} ({label_me(d, value)})")
       ) +
-      ggplot2::xlab(attr(data[[time]], "label") %||% time)
+      ggplot2::xlab(label_me(data, time))
   }
   
   # Add common layers to plot

--- a/R/mod_popExp_fct_spaghettiplot.R
+++ b/R/mod_popExp_fct_spaghettiplot.R
@@ -23,11 +23,11 @@ app_spaghettiplot <- function(data, yvar, time, value = NULL) {
     # initialize plot
     p <- ggplot2::ggplot(data) + 
       ggplot2::aes_string(x = time, y = yvar, group = "USUBJID") +
-      ggplot2::ylab(label_me(data, yvar)) +
-      ggplot2::xlab(label_me(data, time))
+      ggplot2::ylab(best_lab(data, yvar)) +
+      ggplot2::xlab(best_lab(data, time))
     
     # initialize title with variables plotted
-    var_title <- paste(label_me(data, yvar), "by", label_me(data, time))
+    var_title <- paste(best_lab(data, yvar), "by", best_lab(data, time))
     
   } else {
     
@@ -36,16 +36,16 @@ app_spaghettiplot <- function(data, yvar, time, value = NULL) {
     
     # initialize title with variables plotted
     var_label <- paste(unique(d$PARAM))
-    var_title <- paste(var_label, "by", label_me(data, time))
+    var_title <- paste(var_label, "by", best_lab(data, time))
     
     # initialize plot
     p <- d %>%
       ggplot2::ggplot() +
       ggplot2::aes_string(x = time, y = value, group = "USUBJID")  +
       ggplot2::ylab(
-        glue::glue("{var_label} ({label_me(d, value)})")
+        glue::glue("{var_label} ({best_lab(d, value)})")
       ) +
-      ggplot2::xlab(label_me(data, time))
+      ggplot2::xlab(best_lab(data, time))
   }
   
   # Add common layers to plot

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -371,7 +371,7 @@ error_handler.rlang_error <- function(e) {
 #' @return a string containing a useful label
 #'
 #' @noRd
-label_me <- function(data, var_str) {
+best_lab <- function(data, var_str) {
   attr(data[[var_str]], "label") %||% var_str
 }
 

--- a/R/utils_helpers.R
+++ b/R/utils_helpers.R
@@ -358,3 +358,25 @@ error_handler.purrr_error_indexed <-
 error_handler.rlang_error <- function(e) {
   stringr::str_replace_all(rlang::cnd_message(e), "\n.*? ", " ")
 }
+
+#' Extract best variable label
+#'
+#' A function that will grab a label attribute from a given variable, or if one
+#' doesn't exist, it will just use the variable name
+#'
+#' @param data a data.frame, hopefully containing variable label attributes
+#' @param var_str you guessed it, the name of a variable inside of `data`, in
+#'   the form of a string
+#'   
+#' @return a string containing a useful label
+#'
+#' @noRd
+label_me <- function(data, var_str) {
+  attr(data[[var_str]], "label") %||% var_str
+}
+
+
+
+
+
+


### PR DESCRIPTION
This PR
* fix scatterplot fct so that plots can by grouped by `AVISIT` (closes #219)
* Ensures that when label attributes are missing, that at least the variable name is displayed for all plot titles

No entry to the `NEWS` file is needed since this bug came about in PR #212 