### PR TITLE
Update riskmetric badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 [![R-CMD-check](https://github.com/Biogen-Inc/tidyCDISC/workflows/R-CMD-check/badge.svg)](https://github.com/Biogen-Inc/tidyCDISC/actions)
 [![OS
-Health](https://img.shields.io/badge/OS%20Health-71-yellowgreen)](https://openpharma.github.io/GithubMetrics/)
-[![riskmetric](https://img.shields.io/badge/riskmetric-0.48-brightgreen)](https://pharmar.github.io/riskmetric/)
+Health](https://img.shields.io/badge/OS%20Health-86-green)](https://openpharma.github.io/GithubMetrics/)
+[![riskmetric](https://img.shields.io/badge/riskmetric-0.39-brightgreen)](https://pharmar.github.io/riskmetric/)
 [![Coverage
 status](https://codecov.io/gh/Biogen-Inc/tidyCDISC/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Biogen-Inc/tidyCDISC/tree/devel)
 <!-- badges: end -->


### PR DESCRIPTION
Both of our `OS Health` and `riskmetric` badges have improved scores after the recent `v0.2.1` CRAN release, so this PR just updates the badges to reflect those positive changes.